### PR TITLE
Allow options to be passed to Open()

### DIFF
--- a/certstore.go
+++ b/certstore.go
@@ -12,9 +12,20 @@ var (
 	ErrUnsupportedHash = errors.New("unsupported hash algorithm")
 )
 
+type storeConfig struct{}
+
+// StoreOption are options that may be passed to Open()
+type StoreOption func(*storeConfig)
+
 // Open opens the system's certificate store.
-func Open() (Store, error) {
-	return openStore()
+func Open(options ...StoreOption) (Store, error) {
+	cfg := new(storeConfig)
+
+	for _, opt := range options {
+		opt(cfg)
+	}
+
+	return openStore(cfg)
 }
 
 // Store represents the system's certificate store.

--- a/certstore_darwin.go
+++ b/certstore_darwin.go
@@ -37,7 +37,7 @@ var (
 type macStore int
 
 // openStore is a function for opening a macStore.
-func openStore() (macStore, error) {
+func openStore(_ *storeConfig) (macStore, error) {
 	return macStore(0), nil
 }
 

--- a/certstore_windows.go
+++ b/certstore_windows.go
@@ -76,7 +76,7 @@ type winStore struct {
 }
 
 // openStore opens the current user's personal cert store.
-func openStore() (*winStore, error) {
+func openStore(_ *storeConfig) (*winStore, error) {
 	storeName := unsafe.Pointer(stringToUTF16("MY"))
 	defer C.free(storeName)
 


### PR DESCRIPTION
I think this should be a useful construct for https://github.com/mastahyeti/certstore/pull/13. There, we can do

```go
// in certstore.go

type storeConfig struct{
  // NSS options
  nssDBPath string
}

// NSSDBPath provides an option for configuring the NSS database path.
func NSSDBPath(path string) StoreOption {
  return func(cfg *storeConfig) {
    cfg.nssDBPath = path
  }
}
```

/cc @rhowe Does this seem like it will fit into your changes well?