### PR TITLE
Support RSA-PSS on macOS (for TLS 1.3+)

### DIFF
--- a/certstore_test.go
+++ b/certstore_test.go
@@ -139,6 +139,19 @@ func TestSignerRSA(t *testing.T) {
 			}
 		}
 
+		// SHA256WithRSAPSS
+		sha256Digest = sha256.Sum256([]byte("hello"))
+		sig, err = signer.Sign(rand.Reader, sha256Digest[:], &rsa.PSSOptions{Hash: crypto.SHA256})
+		if err == ErrUnsupportedHash {
+			// Some Windows CSPs may not support this algorithm. Pass...
+		} else if err != nil {
+			t.Fatal(err)
+		} else {
+			if err = leafRSA.Certificate.CheckSignature(x509.SHA256WithRSAPSS, []byte("hello"), sig); err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		// SHA384WithRSA
 		sha384Digest := sha512.Sum384([]byte("hello"))
 		sig, err = signer.Sign(rand.Reader, sha384Digest[:], crypto.SHA384)
@@ -152,6 +165,19 @@ func TestSignerRSA(t *testing.T) {
 			}
 		}
 
+		// SHA384WithRSAPSS
+		sha384Digest = sha512.Sum384([]byte("hello"))
+		sig, err = signer.Sign(rand.Reader, sha384Digest[:], &rsa.PSSOptions{Hash: crypto.SHA384})
+		if err == ErrUnsupportedHash {
+			// Some Windows CSPs may not support this algorithm. Pass...
+		} else if err != nil {
+			t.Fatal(err)
+		} else {
+			if err = leafRSA.Certificate.CheckSignature(x509.SHA384WithRSAPSS, []byte("hello"), sig); err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		// SHA512WithRSA
 		sha512Digest := sha512.Sum512([]byte("hello"))
 		sig, err = signer.Sign(rand.Reader, sha512Digest[:], crypto.SHA512)
@@ -161,6 +187,19 @@ func TestSignerRSA(t *testing.T) {
 			t.Fatal(err)
 		} else {
 			if err = leafRSA.Certificate.CheckSignature(x509.SHA512WithRSA, []byte("hello"), sig); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// SHA512WithRSAPSS
+		sha512Digest = sha512.Sum512([]byte("hello"))
+		sig, err = signer.Sign(rand.Reader, sha512Digest[:], &rsa.PSSOptions{Hash: crypto.SHA512})
+		if err == ErrUnsupportedHash {
+			// Some Windows CSPs may not support this algorithm. Pass...
+		} else if err != nil {
+			t.Fatal(err)
+		} else {
+			if err = leafRSA.Certificate.CheckSignature(x509.SHA512WithRSAPSS, []byte("hello"), sig); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/certstore_windows.go
+++ b/certstore_windows.go
@@ -358,6 +358,11 @@ func (wpk *winPrivateKey) Public() crypto.PublicKey {
 
 // Sign implements the crypto.Signer interface.
 func (wpk *winPrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if _, isPSS := opts.(*rsa.PSSOptions); isPSS {
+		// Windows implementation does not currently support RSA-PSS.
+		return nil, ErrUnsupportedHash
+	}
+
 	if wpk.capiProv != 0 {
 		return wpk.capiSignHash(opts.HashFunc(), digest)
 	} else if wpk.cngHandle != 0 {


### PR DESCRIPTION
This pull request adds support for RSA-PSS on macOS to (partially) fix issue https://github.com/github/certstore/issues/17.

Some caveats:
* Apple doesn't allow setting custom salt lengths in SecKeyCreateSignature, it appears to always use the hash output size as the salt length. I've added a check to emit an error when an unsupported salt length is requested.
* Updated the Windows implementation to return "ErrUnsupportedHash" when RSA-PSS is requested so that it doesn't emit an invalid signature.
* I've opted not to add support for RSA-PSS with SHA1 as Go's x509 package doesn't support it for certificate verification.
